### PR TITLE
Fix build failure with TypeScript 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@rollup/plugin-terser": "^1.0.0",
+        "@typescript/typescript6": "^6.0.2",
         "eslint": "^10.1.0",
         "globals": "^17.4.0",
         "jest": "^30.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript/old@npm:typescript@^6":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
 "@typescript/typescript-aix-ppc64@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz#cdc7ce81d60f1e09034960ddfb1fb880d7a776b6"
@@ -1089,6 +1094,13 @@
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz#cf3b7b0d6ce5635daca4c8e01c189cdcde47ec3c"
   integrity sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==
+
+"@typescript/typescript6@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@typescript/typescript6/-/typescript6-6.0.2.tgz#79e0e47492564c83f8602013d7dd10d5ebc51a8c"
+  integrity sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==
+  dependencies:
+    "@typescript/old" "npm:typescript@^6"
 
 "@ungap/structured-clone@^1.3.0":
   version "1.3.0"


### PR DESCRIPTION
This change adds `@typescript/typescript6` as a devDependency to satisfy the TypeScript compiler API requirement of `rollup-plugin-dts` when using TypeScript 7 (`typescript@7.0.2`), resolving build failure while maintaining the upgraded TypeScript version requirement.

---
*PR created automatically by Jules for task [605914426085013002](https://jules.google.com/task/605914426085013002) started by @allemandi*